### PR TITLE
Update VehicleManager.py

### DIFF
--- a/hyundai_kia_connect_api/VehicleManager.py
+++ b/hyundai_kia_connect_api/VehicleManager.py
@@ -107,6 +107,7 @@ class VehicleManager:
         # Otherwise runs a cached update.
         started_at_utc: dt = dt.datetime.now(pytz.utc)
         vehicle = self.get_vehicle(vehicle_id)
+        self.update_vehicle_with_cached_state(vehicle_id)
         if vehicle.last_updated_at is not None:
             _LOGGER.debug(
                 f"{DOMAIN} - Time differential in seconds: {(started_at_utc - vehicle.last_updated_at).total_seconds()}"  # noqa
@@ -115,10 +116,6 @@ class VehicleManager:
                 started_at_utc - vehicle.last_updated_at
             ).total_seconds() > force_refresh_interval:
                 self.force_refresh_vehicle_state(vehicle_id)
-            else:
-                self.update_vehicle_with_cached_state(vehicle_id)
-        else:
-            self.update_vehicle_with_cached_state(vehicle_id)
 
     def force_refresh_all_vehicles_states(self) -> None:
         for vehicle_id in self.vehicles.keys():


### PR DESCRIPTION
Current logic needs `vehicle.last_updated_at` value not to be `None`. However, it stays `None` until we call `self.update_vehicle_with_cached_state(vehicle_id)` . Therefore it never actually force updates the vehicle state and always falls back to `update_vehicle_with_cached_state` call.

This PR fixes the issue by calling the `update_vehicle_with_cached_state` before checking the `last_updated_at` time so that the rest of the logic works.